### PR TITLE
De 2377 backport to java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 
     withJavadocJar()
     withSourcesJar()
@@ -76,16 +76,12 @@ compileJava {
     options.compilerArgs = ["-Xlint:all", "-Werror"]
 }
 
-javadoc {
-    options.addBooleanOption('html5', true)
-}
-
 ext {
     kafkaVersion = "1.1.0"
     // Compatible with Kafka version:
     // https://docs.confluent.io/current/installation/versions-interoperability.html
     confluentPlatformVersion = "4.1.4"
-    aivenConnectCommonsVersion = "0.7.1"
+    aivenConnectCommonsVersion = "0.8.0-SNAPSHOT"
     testcontainersVersion = "1.15.3"
     slf4jVersion = "1.7.30"
 }
@@ -152,6 +148,7 @@ dependencies {
     testImplementation "com.google.cloud:google-cloud-nio:0.84.0-alpha"
     testImplementation "org.mockito:mockito-core:3.3.3"
     testImplementation "io.aiven:commons-for-apache-kafka-connect:$aivenConnectCommonsVersion"
+
 
     testRuntimeOnly "org.slf4j:slf4j-log4j12:$slf4jVersion"
     testImplementation "org.xerial.snappy:snappy-java:1.1.7.5"

--- a/src/integration-test/java/io/aiven/kafka/connect/gcs/AvroParquetIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/gcs/AvroParquetIntegrationTest.java
@@ -117,7 +117,7 @@ final class AvroParquetIntegrationTest extends AbstractIntegrationTest {
     @Test
     final void allOutputFields(@TempDir final Path tmpDir)
             throws ExecutionException, InterruptedException, IOException {
-        final var compression = "none";
+        final String compression = "none";
         final Map<String, String> connectorConfig = basicConnectorConfig(compression);
         connectorConfig.put("format.output.fields", "key,value,offset,timestamp,headers");
         connectorConfig.put("format.output.fields.value.encoding", "none");
@@ -134,7 +134,7 @@ final class AvroParquetIntegrationTest extends AbstractIntegrationTest {
         int cnt = 0;
         for (int i = 0; i < 10; i++) {
             for (int partition = 0; partition < 4; partition++) {
-                final var key = "key-" + cnt;
+                final String key = "key-" + cnt;
                 final GenericRecord value = new GenericData.Record(valueSchema);
                 value.put("name", "user-" + cnt);
                 value.put("value", "value-" + cnt);
@@ -150,7 +150,7 @@ final class AvroParquetIntegrationTest extends AbstractIntegrationTest {
         // TODO more robust way to detect that Connect finished processing
         Thread.sleep(OFFSET_FLUSH_INTERVAL_MS * 2);
 
-        final List<String> expectedBlobs = List.of(
+        final List<String> expectedBlobs = Arrays.asList(
                 getBlobName(0, 0, compression),
                 getBlobName(1, 0, compression),
                 getBlobName(2, 0, compression),
@@ -159,7 +159,7 @@ final class AvroParquetIntegrationTest extends AbstractIntegrationTest {
 
         final Map<String, List<GenericRecord>> blobContents = new HashMap<>();
         for (final String blobName : expectedBlobs) {
-            final var records =
+            final List<GenericRecord> records =
                     ParquetUtils.readRecords(
                             tmpDir.resolve(Paths.get(blobName)),
                             testBucketAccessor.readBytes(blobName)
@@ -169,12 +169,12 @@ final class AvroParquetIntegrationTest extends AbstractIntegrationTest {
         cnt = 0;
         for (int i = 0; i < 10; i++) {
             for (int partition = 0; partition < 4; partition++) {
-                final var name = "user-" + cnt;
-                final var value = "value-" + cnt;
+                final String name = "user-" + cnt;
+                final String value = "value-" + cnt;
                 final String blobName = getBlobName(partition, 0, "none");
                 final GenericRecord record = blobContents.get(blobName).get(i);
-                final var expectedKey = "key-" + cnt;
-                final var expectedValue = "{\"name\": \"" + name + "\", \"value\": \"" + value + "\"}";
+                final String expectedKey = "key-" + cnt;
+                final String expectedValue = "{\"name\": \"" + name + "\", \"value\": \"" + value + "\"}";
                 assertEquals(expectedKey, record.get("key").toString());
                 assertEquals(expectedValue, record.get("value").toString());
                 assertNotNull(record.get("offset"));
@@ -205,7 +205,7 @@ final class AvroParquetIntegrationTest extends AbstractIntegrationTest {
         int cnt = 0;
         for (int i = 0; i < 10; i++) {
             for (int partition = 0; partition < 4; partition++) {
-                final var key = "key-" + cnt;
+                final String key = "key-" + cnt;
                 final GenericRecord value = new GenericData.Record(valueSchema);
                 value.put("name", "user-" + cnt);
                 value.put("value", "value-" + cnt);
@@ -221,7 +221,7 @@ final class AvroParquetIntegrationTest extends AbstractIntegrationTest {
         // TODO more robust way to detect that Connect finished processing
         Thread.sleep(OFFSET_FLUSH_INTERVAL_MS * 2);
 
-        final List<String> expectedBlobs = List.of(
+        final List<String> expectedBlobs = Arrays.asList(
                 getBlobName(0, 0, compression),
                 getBlobName(1, 0, compression),
                 getBlobName(2, 0, compression),
@@ -230,7 +230,7 @@ final class AvroParquetIntegrationTest extends AbstractIntegrationTest {
 
         final Map<String, List<GenericRecord>> blobContents = new HashMap<>();
         for (final String blobName : expectedBlobs) {
-            final var records =
+            final List<GenericRecord> records =
                     ParquetUtils.readRecords(
                             tmpDir.resolve(Paths.get(blobName)),
                             testBucketAccessor.readBytes(blobName)
@@ -240,11 +240,11 @@ final class AvroParquetIntegrationTest extends AbstractIntegrationTest {
         cnt = 0;
         for (int i = 0; i < 10; i++) {
             for (int partition = 0; partition < 4; partition++) {
-                final var name = "user-" + cnt;
-                final var value = "value-" + cnt;
+                final String name = "user-" + cnt;
+                final String value = "value-" + cnt;
                 final String blobName = getBlobName(partition, 0, "none");
                 final GenericRecord record = blobContents.get(blobName).get(i);
-                final var recordValue = (GenericRecord) record.get("value");
+                final GenericRecord recordValue = (GenericRecord) record.get("value");
                 assertEquals(name, recordValue.get("name").toString());
                 assertEquals(value, recordValue.get("value").toString());
                 cnt += 1;
@@ -278,10 +278,10 @@ final class AvroParquetIntegrationTest extends AbstractIntegrationTest {
 
         final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
         int cnt = 0;
-        final var expectedRecords = new ArrayList<String>();
+        final List<String> expectedRecords = new ArrayList<String>();
         for (int i = 0; i < 10; i++) {
             for (int partition = 0; partition < 4; partition++) {
-                final var key = "key-" + cnt;
+                final String key = "key-" + cnt;
                 final GenericRecord value;
                 if (i < 5) {
                     value = new GenericData.Record(valueSchema);
@@ -318,9 +318,9 @@ final class AvroParquetIntegrationTest extends AbstractIntegrationTest {
         );
         assertIterableEquals(expectedBlobs, testBucketAccessor.getBlobNames(gcsPrefix));
 
-        final var blobContents = new ArrayList<String>();
+        final List<String> blobContents = new ArrayList<String>();
         for (final String blobName : expectedBlobs) {
-            final var records =
+            final List<GenericRecord> records =
                     ParquetUtils.readRecords(
                             tmpDir.resolve(Paths.get(blobName)),
                             testBucketAccessor.readBytes(blobName)

--- a/src/integration-test/java/io/aiven/kafka/connect/gcs/ParquetIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/gcs/ParquetIntegrationTest.java
@@ -110,7 +110,7 @@ final class ParquetIntegrationTest extends AbstractIntegrationTest {
     @Test
     final void allOutputFields()
             throws ExecutionException, InterruptedException, IOException {
-        final var compression = "none";
+        final String compression = "none";
         final Map<String, String> connectorConfig = basicConnectorConfig(compression);
         connectorConfig.put("format.output.fields", "key,value,offset,timestamp,headers");
         connectorConfig.put("format.output.fields.value.encoding", "none");
@@ -145,7 +145,7 @@ final class ParquetIntegrationTest extends AbstractIntegrationTest {
 
         final Map<String, List<GenericRecord>> blobContents = new HashMap<>();
         for (final String blobName : expectedBlobs) {
-            final var records =
+            final List<GenericRecord> records =
                     ParquetUtils.readRecords(
                             tmpDir.resolve(Paths.get(blobName)),
                             testBucketAccessor.readBytes(blobName)
@@ -155,10 +155,10 @@ final class ParquetIntegrationTest extends AbstractIntegrationTest {
         cnt = 0;
         for (int i = 0; i < 10; i++) {
             for (int partition = 0; partition < 4; partition++) {
-                final var key = "key-" + cnt;
-                final var value = "value-" + cnt;
+                final String key = "key-" + cnt;
+                final String value = "value-" + cnt;
                 final String blobName = getBlobName(partition, 0, compression);
-                final var record = blobContents.get(blobName).get(i);
+                final GenericRecord record = blobContents.get(blobName).get(i);
                 assertEquals(key, record.get("key").toString());
                 assertEquals(value, record.get("value").toString());
                 assertNotNull(record.get("offset"));
@@ -172,7 +172,7 @@ final class ParquetIntegrationTest extends AbstractIntegrationTest {
     @Test
     final void allOutputFieldsJsonValueAsString()
             throws ExecutionException, InterruptedException, IOException {
-        final var compression = "none";
+        final String compression = "none";
         final Map<String, String> connectorConfig = basicConnectorConfig(compression);
         connectorConfig.put("format.output.fields", "key,value,offset,timestamp,headers");
         connectorConfig.put("format.output.fields.value.encoding", "none");
@@ -207,7 +207,7 @@ final class ParquetIntegrationTest extends AbstractIntegrationTest {
 
         final Map<String, List<GenericRecord>> blobContents = new HashMap<>();
         for (final String blobName : expectedBlobs) {
-            final var records =
+            final List<GenericRecord> records =
                     ParquetUtils.readRecords(
                             tmpDir.resolve(Paths.get(blobName)),
                             testBucketAccessor.readBytes(blobName)
@@ -217,10 +217,10 @@ final class ParquetIntegrationTest extends AbstractIntegrationTest {
         cnt = 0;
         for (int i = 0; i < 10; i++) {
             for (int partition = 0; partition < 4; partition++) {
-                final var key = "key-" + cnt;
-                final var value = "{\"name\": \"name-" + cnt + "\", \"value\": \"value-" + cnt + "\"}";
+                final String key = "key-" + cnt;
+                final String value = "{\"name\": \"name-" + cnt + "\", \"value\": \"value-" + cnt + "\"}";
                 final String blobName = getBlobName(partition, 0, compression);
-                final var record = blobContents.get(blobName).get(i);
+                final GenericRecord record = blobContents.get(blobName).get(i);
                 assertEquals(key, record.get("key").toString());
                 assertEquals(value, record.get("value").toString());
                 assertNotNull(record.get("offset"));
@@ -235,7 +235,7 @@ final class ParquetIntegrationTest extends AbstractIntegrationTest {
     @CsvSource({"true, {\"value\": {\"name\": \"%s\"}} ", "false, {\"name\": \"%s\"}"})
     final void jsonValue(final String envelopeEnabled, final String expectedOutput)
             throws ExecutionException, InterruptedException, IOException {
-        final var compression = "none";
+        final String compression = "none";
         final Map<String, String> connectorConfig = basicConnectorConfig(compression);
         connectorConfig.put("format.output.fields", "value");
         connectorConfig.put("format.output.envelope", envelopeEnabled);
@@ -244,8 +244,8 @@ final class ParquetIntegrationTest extends AbstractIntegrationTest {
         connectorConfig.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
         connectRunner.createConnector(connectorConfig);
 
-        final var jsonMessageSchema = "{\"type\":\"struct\",\"fields\":[{\"type\":\"string\",\"field\":\"name\"}]}";
-        final var jsonMessagePattern = "{\"schema\": %s, \"payload\": %s}";
+        final String jsonMessageSchema = "{\"type\":\"struct\",\"fields\":[{\"type\":\"string\",\"field\":\"name\"}]}";
+        final String jsonMessagePattern = "{\"schema\": %s, \"payload\": %s}";
 
         final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
         int cnt = 0;
@@ -279,7 +279,7 @@ final class ParquetIntegrationTest extends AbstractIntegrationTest {
 
         final Map<String, List<GenericRecord>> blobContents = new HashMap<>();
         for (final String blobName : expectedBlobs) {
-            final var records =
+            final List<GenericRecord> records =
                     ParquetUtils.readRecords(
                             tmpDir.resolve(Paths.get(blobName)),
                             testBucketAccessor.readBytes(blobName)
@@ -289,9 +289,9 @@ final class ParquetIntegrationTest extends AbstractIntegrationTest {
         cnt = 0;
         for (int i = 0; i < 10; i++) {
             for (int partition = 0; partition < 4; partition++) {
-                final var name = "user-" + cnt;
+                final String name = "user-" + cnt;
                 final String blobName = getBlobName(partition, 0, compression);
-                final var record = blobContents.get(blobName).get(i);
+                final GenericRecord record = blobContents.get(blobName).get(i);
                 final String expectedLine = String.format(expectedOutput, name);
                 assertEquals(expectedLine, record.toString());
                 cnt += 1;
@@ -302,7 +302,7 @@ final class ParquetIntegrationTest extends AbstractIntegrationTest {
     @Test
     final void schemaChanged()
             throws ExecutionException, InterruptedException, IOException {
-        final var compression = "none";
+        final String compression = "none";
         final Map<String, String> connectorConfig = basicConnectorConfig(compression);
         connectorConfig.put("format.output.fields", "value");
         connectorConfig.put("format.output.fields.value.encoding", "none");
@@ -310,18 +310,18 @@ final class ParquetIntegrationTest extends AbstractIntegrationTest {
         connectorConfig.put("value.converter", "org.apache.kafka.connect.json.JsonConverter");
         connectRunner.createConnector(connectorConfig);
 
-        final var jsonMessageSchema = "{\"type\":\"struct\",\"fields\":[{\"type\":\"string\",\"field\":\"name\"}]}";
-        final var jsonMessageNewSchema = "{\"type\":\"struct\",\"fields\":"
+        final String jsonMessageSchema = "{\"type\":\"struct\",\"fields\":[{\"type\":\"string\",\"field\":\"name\"}]}";
+        final String jsonMessageNewSchema = "{\"type\":\"struct\",\"fields\":"
                 + "[{\"type\":\"string\",\"field\":\"name\"}, "
                 + "{\"type\":\"string\",\"field\":\"value\", \"default\": \"foo\"}]}";
-        final var jsonMessagePattern = "{\"schema\": %s, \"payload\": %s}";
+        final String jsonMessagePattern = "{\"schema\": %s, \"payload\": %s}";
 
         final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
-        final var expectedRecords = new ArrayList<String>();
+        final List<String> expectedRecords = new ArrayList<String>();
         int cnt = 0;
         for (int i = 0; i < 10; i++) {
             for (int partition = 0; partition < 4; partition++) {
-                final var key = "key-" + cnt;
+                final String key = "key-" + cnt;
                 final String value;
                 final String payload;
                 if (i < 5) {
@@ -356,9 +356,9 @@ final class ParquetIntegrationTest extends AbstractIntegrationTest {
         );
         assertIterableEquals(expectedBlobs, testBucketAccessor.getBlobNames(gcsPrefix));
 
-        final var blobContents = new ArrayList<String>();
+        final List<String> blobContents = new ArrayList<String>();
         for (final String blobName : expectedBlobs) {
-            final var records =
+            final List<GenericRecord> records =
                     ParquetUtils.readRecords(
                             tmpDir.resolve(Paths.get(blobName)),
                             testBucketAccessor.readBytes(blobName)

--- a/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkConfig.java
@@ -145,7 +145,7 @@ public final class GcsSinkConfig extends AivenCommonConfig {
     }
 
     private static void addGcsRetryPolicies(final ConfigDef configDef) {
-        var retryPolicyGroupCounter = 0;
+        int retryPolicyGroupCounter = 0;
         configDef.define(
                 GCS_RETRY_BACKOFF_INITIAL_DELAY_MS_CONFIG,
                 ConfigDef.Type.LONG,
@@ -212,7 +212,7 @@ public final class GcsSinkConfig extends AivenCommonConfig {
                             return;
                         }
                         assert value instanceof Long;
-                        final var longValue = (Long) value;
+                        final Long longValue = (Long) value;
                         if (longValue < 0) {
                             throw new ConfigException(name, value, "Value must be at least 0");
                         } else if (longValue > TOTAL_TIME_MAX) {
@@ -393,14 +393,14 @@ public final class GcsSinkConfig extends AivenCommonConfig {
 
     static Map<String, String> handleDeprecatedYyyyUppercase(final Map<String, String> properties) {
         if (properties.containsKey(FILE_NAME_TEMPLATE_CONFIG)) {
-            final var result = new HashMap<>(properties);
+            final Map<String, String> result = new HashMap<>(properties);
 
             String template = properties.get(FILE_NAME_TEMPLATE_CONFIG);
             final String originalTemplate = template;
 
-            final var unitYyyyPattern = Pattern.compile("\\{\\{\\s*timestamp\\s*:\\s*unit\\s*=\\s*YYYY\\s*}}");
+            final Pattern unitYyyyPattern = Pattern.compile("\\{\\{\\s*timestamp\\s*:\\s*unit\\s*=\\s*YYYY\\s*}}");
             template = unitYyyyPattern.matcher(template)
-                .replaceAll(matchResult -> matchResult.group().replace("YYYY", "yyyy"));
+                .replaceAll("{{timestamp: unit=yyyy}}");
 
             if (!template.equals(originalTemplate)) {
                 log.warn("{{timestamp:unit=YYYY}} is no longer supported, "

--- a/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkConfig.java
@@ -400,7 +400,7 @@ public final class GcsSinkConfig extends AivenCommonConfig {
 
             final Pattern unitYyyyPattern = Pattern.compile("\\{\\{\\s*timestamp\\s*:\\s*unit\\s*=\\s*YYYY\\s*}}");
             template = unitYyyyPattern.matcher(template)
-                .replaceAll("{{timestamp: unit=yyyy}}");
+                .replaceAll("{{timestamp:unit=yyyy}}");
 
             if (!template.equals(originalTemplate)) {
                 log.warn("{{timestamp:unit=YYYY}} is no longer supported, "

--- a/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkTask.java
@@ -16,6 +16,7 @@
 
 package io.aiven.kafka.connect.gcs;
 
+import java.io.OutputStream;
 import java.nio.channels.Channels;
 import java.util.Collection;
 import java.util.List;
@@ -115,8 +116,8 @@ public final class GcsSinkTask extends SinkTask {
         final BlobInfo blob = BlobInfo
                 .newBuilder(config.getBucketName(), config.getPrefix() + filename)
                 .build();
-        try (final var out = Channels.newOutputStream(storage.writer(blob));
-             final var writer = OutputWriter.builder()
+        try (final OutputStream out = Channels.newOutputStream(storage.writer(blob));
+             final OutputWriter writer = OutputWriter.builder()
                      .withExternalProperties(config.originalsStrings())
                      .withOutputFields(config.getOutputFields())
                      .withCompressionType(config.getCompressionType())

--- a/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
@@ -152,10 +152,12 @@ final class GcsSinkConfigTest {
 
     @Test
     void emptyGcsBucketName() {
-        final Map<String, String> properties = new HashMap<String, String>();
+        final Map<String, String> properties = new HashMap<String, String>() {{
+                put("gcs.bucket.name", "");    
+            }};
 
         final String expectedErrorMessage =
-            "Missing required configuration \"gcs.bucket.name\" which has no default value.";
+            "Invalid value  for configuration gcs.bucket.name: String must be non-empty";
 
         expectErrorMessageForConfigurationInConfigDefValidation(
             properties, "gcs.bucket.name", expectedErrorMessage);

--- a/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
@@ -155,7 +155,7 @@ final class GcsSinkConfigTest {
         final Map<String, String> properties = new HashMap<String, String>();
 
         final String expectedErrorMessage =
-            "Invalid value  for configuration gcs.bucket.name: String must be non-empty";
+            "Missing required configuration \"gcs.bucket.name\" which has no default value.";
 
         expectErrorMessageForConfigurationInConfigDefValidation(
             properties, "gcs.bucket.name", expectedErrorMessage);
@@ -267,6 +267,7 @@ final class GcsSinkConfigTest {
                         + "Value must be at least 0", maxAttemptsE.getMessage());
 
         final Map<String, String> totalTimeoutProp = new HashMap<String, String>() {{ 
+                put("gcs.bucket.name", "test-bucket");
                 put("gcs.retry.backoff.total.timeout.ms", "-1");
             }};
         final ConfigException totalTimeoutE =
@@ -276,6 +277,7 @@ final class GcsSinkConfigTest {
                         + "Value must be at least 0", totalTimeoutE.getMessage());
 
         final Map<String, String> tooBigTotoalTimeoutProp = new HashMap<String, String>() {{
+                put("gcs.bucket.name", "test-bucket");
                 put("gcs.retry.backoff.total.timeout.ms", String.valueOf(TimeUnit.HOURS.toMillis(25)));
             }};
 
@@ -799,7 +801,7 @@ final class GcsSinkConfigTest {
 
         final String expectedErrorMessage = "Invalid value {{:padding=true}}-{{partition}}-{{topic}} "
             + "for configuration file.name.template: "
-            + "Variable name has't been set for template: {{:padding=true}}-{{partition}}-{{topic}}";
+            + "Variable name hasn't been set for template: {{:padding=true}}-{{partition}}-{{topic}}";
 
         expectErrorMessageForConfigurationInConfigDefValidation(
             properties, "file.name.template", expectedErrorMessage);


### PR DESCRIPTION
Modified build to use locally built aiven-common jar. Also modified the following things to be backported to java 8:

* `List.of` replaced with `Arrays.asList`
* `Map.of` replaced with `new HashMap<String, String>() {{ put(key, value); }}` pattern
* `var` into `String` and other corresponding types
* one case of `replaceAll` with lambda functions, replaced with string directly
* some errors where modified on testing layer. I think it's because Java 8 had different error handling.